### PR TITLE
Update pipelines to remove deprecation warnings

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -11,7 +11,7 @@ jobs:
   plan:
   - get: service-instance-reaper
     trigger: true
-  - aggregate:
+  - in_parallel:
     - task: build
       file: service-instance-reaper/ci/tasks/build.yml
     - task: test


### PR DESCRIPTION
`aggregate` becomes `in_parallel`

connected to #970